### PR TITLE
feat: Implement Label Maker endpoints

### DIFF
--- a/homebox-mcp-server/TODO.md
+++ b/homebox-mcp-server/TODO.md
@@ -21,9 +21,9 @@ This file lists the remaining endpoints from the Homebox API specification that 
 - [x] `GET /v1/groups/statistics/purchase-price`
 
 ## Label Maker
-- [ ] `GET /v1/labelmaker/assets/{id}` (returns image)
-- [ ] `GET /v1/labelmaker/item/{id}` (returns image)
-- [ ] `GET /v1/labelmaker/location/{id}` (returns image)
+- [x] `GET /v1/labelmaker/assets/{id}` (returns image)
+- [x] `GET /v1/labelmaker/item/{id}` (returns image)
+- [x] `GET /v1/labelmaker/location/{id}` (returns image)
 
 ## Maintenance
 - [x] `PUT /v1/maintenance/{id}`

--- a/homebox-mcp-server/main.go
+++ b/homebox-mcp-server/main.go
@@ -599,6 +599,34 @@ type CreateQRCodeInput struct {
 // Reporting Inputs
 type ExportBillOfMaterialsInput struct{}
 
+// Label Maker Inputs
+type GetLabelForAssetInput struct {
+	ID string `json:"id" jsonschema:"required"`
+}
+
+type GetLabelForAssetOutput struct {
+	FileContent string `json:"file_content"`
+	ContentType string `json:"content_type"`
+}
+
+type GetLabelForItemInput struct {
+	ID string `json:"id" jsonschema:"required"`
+}
+
+type GetLabelForItemOutput struct {
+	FileContent string `json:"file_content"`
+	ContentType string `json:"content_type"`
+}
+
+type GetLabelForLocationInput struct {
+	ID string `json:"id" jsonschema:"required"`
+}
+
+type GetLabelForLocationOutput struct {
+	FileContent string `json:"file_content"`
+	ContentType string `json:"content_type"`
+}
+
 
 // getItems is the implementation of the "get_items" tool.
 func getItems(ctx context.Context, req *mcp.CallToolRequest, input GetItemsInput) (*mcp.CallToolResult, GetItemsOutput, error) {
@@ -1902,6 +1930,87 @@ func createGroupInvitation(ctx context.Context, req *mcp.CallToolRequest, input 
     return nil, invitation, nil
 }
 
+// getLabel is a helper function to get a label for a given type and ID.
+func getLabel(labelType string, id string) (string, string, error) {
+	// Get the Homebox API URL and token from environment variables.
+	homeboxURL := os.Getenv("HOMEBOX_URL")
+	homeboxToken := os.Getenv("HOMEBOX_TOKEN")
+
+	if homeboxURL == "" || homeboxToken == "" {
+		return "", "", fmt.Errorf("HOMEBOX_URL and HOMEBOX_TOKEN environment variables must be set")
+	}
+
+	// Create a new HTTP request to the Homebox API.
+	httpReq, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/labelmaker/%s/%s", homeboxURL, labelType, id), nil)
+	if err != nil {
+		return "", "", err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+homeboxToken)
+
+	// Execute the request.
+	client := &http.Client{}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	// Read the response body.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("failed to get label for %s, status code: %d, body: %s", labelType, resp.StatusCode, string(body))
+	}
+
+	// Encode the body to base64
+	encodedBody := base64.StdEncoding.EncodeToString(body)
+
+	// Return the image
+	return encodedBody, resp.Header.Get("Content-Type"), nil
+}
+
+// getLabelForAsset is the implementation of the "get_label_for_asset" tool.
+func getLabelForAsset(ctx context.Context, req *mcp.CallToolRequest, input GetLabelForAssetInput) (*mcp.CallToolResult, GetLabelForAssetOutput, error) {
+	fileContent, contentType, err := getLabel("assets", input.ID)
+	if err != nil {
+		return nil, GetLabelForAssetOutput{}, err
+	}
+
+	return nil, GetLabelForAssetOutput{
+		FileContent: fileContent,
+		ContentType: contentType,
+	}, nil
+}
+
+// getLabelForItem is the implementation of the "get_label_for_item" tool.
+func getLabelForItem(ctx context.Context, req *mcp.CallToolRequest, input GetLabelForItemInput) (*mcp.CallToolResult, GetLabelForItemOutput, error) {
+	fileContent, contentType, err := getLabel("item", input.ID)
+	if err != nil {
+		return nil, GetLabelForItemOutput{}, err
+	}
+
+	return nil, GetLabelForItemOutput{
+		FileContent: fileContent,
+		ContentType: contentType,
+	}, nil
+}
+
+// getLabelForLocation is the implementation of the "get_label_for_location" tool.
+func getLabelForLocation(ctx context.Context, req *mcp.CallToolRequest, input GetLabelForLocationInput) (*mcp.CallToolResult, GetLabelForLocationOutput, error) {
+	fileContent, contentType, err := getLabel("location", input.ID)
+	if err != nil {
+		return nil, GetLabelForLocationOutput{}, err
+	}
+
+	return nil, GetLabelForLocationOutput{
+		FileContent: fileContent,
+		ContentType: contentType,
+	}, nil
+}
+
 func main() {
 	// Create a new MCP server.
 	server := mcp.NewServer(&mcp.Implementation{Name: "homebox-mcp-server", Version: "v0.0.1"}, nil)
@@ -2047,6 +2156,20 @@ func main() {
 	    Name:        "create_group_invitation",
 	    Description: "Creates a new group invitation.",
 	}, createGroupInvitation)
+
+	// Label Maker tools
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_label_for_asset",
+		Description: "Gets a label for an asset as a PNG image.",
+	}, getLabelForAsset)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_label_for_item",
+		Description: "Gets a label for an item as a PNG image.",
+	}, getLabelForItem)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_label_for_location",
+		Description: "Gets a label for a location as a PNG image.",
+	}, getLabelForLocation)
 
 	// Start the server, which will listen for connections on stdin/stdout.
 	log.Println("Starting Homebox MCP server...")


### PR DESCRIPTION
This commit implements the three Label Maker endpoints:
- GET /v1/labelmaker/assets/{id}
- GET /v1/labelmaker/item/{id}
- GET /v1/labelmaker/location/{id}

These endpoints return a PNG image of the label for the corresponding asset, item, or location.

A helper function `getLabel` has been created to reduce code duplication. The three new tool functions `getLabelForAsset`, `getLabelForItem`, and `getLabelForLocation` all use this helper function.

The new tools have been registered in the `main` function and the `TODO.md` file has been updated.